### PR TITLE
異なるgeometry typeが混在するGPXファイルの読み込みに対応

### DIFF
--- a/src/components/AltitudeChartPanel.tsx
+++ b/src/components/AltitudeChartPanel.tsx
@@ -1,12 +1,12 @@
 import Chart from '@/components/Chart';
-import { GeoJSONFeature } from '@/store/geojsonStore';
+import { GeoJSON } from '@/store/geojsonStore';
 
 interface AltitudeChartPanelProps {
-  feature: GeoJSONFeature | null;
+  fc: GeoJSON | null;
   onHoverIndex?: (idx: number | null) => void;
 }
 
-export default function AltitudeChartPanel({ feature, onHoverIndex }: AltitudeChartPanelProps) {
+export default function AltitudeChartPanel({ fc, onHoverIndex }: AltitudeChartPanelProps) {
   return (
     <div className="bg-white shadow-lg p-2 md:p-4 border-t w-full max-w-none sm:max-w-3xl md:max-w-4xl lg:max-w-6xl xl:max-w-7xl mx-auto">
       <div className="text-base md:text-lg font-semibold text-gray-700 mb-2 flex items-center gap-2">
@@ -28,7 +28,7 @@ export default function AltitudeChartPanel({ feature, onHoverIndex }: AltitudeCh
         高度グラフ
         <span className="text-xs text-gray-400 ml-2">(標高プロファイル)</span>
       </div>
-      <Chart feature={feature} onHoverIndex={onHoverIndex} />
+      <Chart fc={fc} onHoverIndex={onHoverIndex} />
     </div>
   );
 }

--- a/src/components/Chart.tsx
+++ b/src/components/Chart.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
 import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts';
-import { GeoJSONFeature } from '@/store/geojsonStore';
+import { GeoJSON, GeoJSONFeature } from '@/store/geojsonStore';
 
 function haversine(lat1: number, lon1: number, lat2: number, lon2: number): number {
   const R = 6371000; // 地球半径[m]
@@ -15,17 +14,27 @@ function haversine(lat1: number, lon1: number, lat2: number, lon2: number): numb
   return R * c;
 }
 
-// coordinates: [lng, lat, alt?]
+function extractLineCoords(features: GeoJSONFeature[]): number[][] {
+  const coords: number[][] = [];
+  for (const f of features) {
+    if (f.geometry.type === 'LineString') {
+      coords.push(...f.geometry.coordinates);
+    } else if (f.geometry.type === 'MultiLineString') {
+      coords.push(...f.geometry.coordinates.flat());
+    }
+  }
+  return coords;
+}
+
 type ChartProps = {
-  feature: GeoJSONFeature | null;
+  fc: GeoJSON | null;
   onHoverIndex?: (idx: number | null) => void;
 };
 
-export default function Chart({ feature, onHoverIndex }: ChartProps) {
-  // 標高データと累積距離を抽出
+export default function Chart({ fc, onHoverIndex }: ChartProps) {
   let data: { idx: number; alt: number; distance: number }[] = [];
-  if (feature && feature.geometry.type === 'LineString') {
-    const coords = feature.geometry.coordinates;
+  if (fc) {
+    const coords = extractLineCoords(fc.features);
     let sum = 0;
     data = coords.map((c: any, i: number) => {
       let d = 0;
@@ -36,22 +45,7 @@ export default function Chart({ feature, onHoverIndex }: ChartProps) {
       return {
         idx: i,
         alt: typeof c[2] === 'number' ? c[2] : 0,
-        distance: +(sum / 1000).toFixed(3) // km単位, 小数3桁
-      };
-    });
-  } else if (feature && feature.geometry.type === 'MultiLineString') {
-    const coords = feature.geometry.coordinates.flat();
-    let sum = 0;
-    data = coords.map((c: any, i: number) => {
-      let d = 0;
-      if (i > 0) {
-        d = haversine(coords[i-1][1], coords[i-1][0], c[1], c[0]);
-      }
-      sum += d;
-      return {
-        idx: i,
-        alt: typeof c[2] === 'number' ? c[2] : 0,
-        distance: +(sum / 1000).toFixed(3) // km単位, 小数3桁
+        distance: +(sum / 1000).toFixed(3),
       };
     });
   }

--- a/src/components/Chart.tsx
+++ b/src/components/Chart.tsx
@@ -1,5 +1,6 @@
 import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts';
-import { GeoJSON, GeoJSONFeature } from '@/store/geojsonStore';
+import { GeoJSON } from '@/store/geojsonStore';
+import { extractLineCoords } from '@/utils/extractLineCoords';
 
 function haversine(lat1: number, lon1: number, lat2: number, lon2: number): number {
   const R = 6371000; // 地球半径[m]
@@ -12,18 +13,6 @@ function haversine(lat1: number, lon1: number, lat2: number, lon2: number): numb
     Math.sin(dLon / 2) * Math.sin(dLon / 2);
   const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
   return R * c;
-}
-
-function extractLineCoords(features: GeoJSONFeature[]): number[][] {
-  const coords: number[][] = [];
-  for (const f of features) {
-    if (f.geometry.type === 'LineString') {
-      coords.push(...f.geometry.coordinates);
-    } else if (f.geometry.type === 'MultiLineString') {
-      coords.push(...f.geometry.coordinates.flat());
-    }
-  }
-  return coords;
 }
 
 type ChartProps = {

--- a/src/components/DownloadButton.tsx
+++ b/src/components/DownloadButton.tsx
@@ -1,13 +1,13 @@
-import React from 'react';
 import { useGeojsonStore } from '@/store/geojsonStore';
 import { downloadGeoData } from '@/utils/download';
 
 export default function DownloadButton() {
   const mergedGeojson = useGeojsonStore((s) => s.mergedGeojson);
+  const rawGpxTexts = useGeojsonStore((s) => s.rawGpxTexts);
 
   const handleDownload = (ext: 'geojson' | 'gpx') => {
     if (!mergedGeojson) return;
-    downloadGeoData(mergedGeojson, ext);
+    downloadGeoData(mergedGeojson, ext, rawGpxTexts);
   };
 
   return (

--- a/src/components/GeojsonUploader.tsx
+++ b/src/components/GeojsonUploader.tsx
@@ -8,6 +8,8 @@ type FileItem = {
   file: File;
   name: string;
   geojson: GeoJSON;
+  rawText: string;
+  isGpx: boolean;
 };
 
 // アップロード用アイコンSVG
@@ -20,9 +22,15 @@ const UploadIcon = () => (
 
 export default function GeojsonUploader() {
   const setMergedGeojson = useGeojsonStore((s) => s.setMergedGeojson);
+  const setRawGpxTexts = useGeojsonStore((s) => s.setRawGpxTexts);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [dragActive, setDragActive] = useState(false);
   const [fileItems, setFileItems] = useState<FileItem[]>([]);
+
+  const updateStore = (items: FileItem[]) => {
+    setMergedGeojson(mergeGeojsons(items.map(f => f.geojson)));
+    setRawGpxTexts(items.filter(f => f.isGpx).map(f => f.rawText));
+  };
 
   // ファイル追加
   const handleFilesProcess = async (files: FileList | null) => {
@@ -30,23 +38,25 @@ export default function GeojsonUploader() {
     const newItems: FileItem[] = [];
     for (let i = 0; i < files.length; i++) {
       const file = files[i];
-      const geojson = await fileToGeojson(file);
+      const rawText = await file.text();
+      const isGpx = file.name.toLowerCase().endsWith('.gpx') || file.type === 'application/gpx+xml';
+      const geojson = await fileToGeojson(file, rawText);
       if (geojson) {
-        newItems.push({ file, name: file.name, geojson });
-      } else if (file.name.toLowerCase().endsWith('.gpx')) {
+        newItems.push({ file, name: file.name, geojson, rawText, isGpx });
+      } else if (isGpx) {
         alert('GPXファイルの読み込みに失敗しました: ' + file.name);
       }
     }
     const mergedList = [...fileItems, ...newItems];
     setFileItems(mergedList);
-    setMergedGeojson(mergeGeojsons(mergedList.map(f => f.geojson)));
+    updateStore(mergedList);
   };
 
   // ファイル削除
   const removeItem = (idx: number) => {
     const updated = fileItems.filter((_, i) => i !== idx);
     setFileItems(updated);
-    setMergedGeojson(mergeGeojsons(updated.map(f => f.geojson)));
+    updateStore(updated);
   };
 
   // input change
@@ -81,6 +91,7 @@ export default function GeojsonUploader() {
   const clearAll = () => {
     setFileItems([]);
     setMergedGeojson(null);
+    setRawGpxTexts([]);
   };
 
   // 並び替え（DnD）
@@ -90,7 +101,7 @@ export default function GeojsonUploader() {
     const [removed] = updated.splice(result.source.index, 1);
     updated.splice(result.destination.index, 0, removed);
     setFileItems(updated);
-    setMergedGeojson(mergeGeojsons(updated.map(f => f.geojson)));
+    updateStore(updated);
   };
 
   return (

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -1,6 +1,6 @@
-import React, { useMemo, useRef, useEffect } from 'react';
+import { useMemo, useRef, useEffect } from 'react';
 import Map, { Source, Layer, ViewState, MapRef } from '@vis.gl/react-maplibre';
-import { useGeojsonStore } from '@/store/geojsonStore';
+import { useGeojsonStore, GeoJSONFeature } from '@/store/geojsonStore';
 import { getGeojsonBounds } from '@/utils/geojsonBounds';
 
 // MapTiler Streets スタイル
@@ -14,22 +14,54 @@ const INITIAL_VIEW_STATE: Partial<ViewState> = {
 const lineLayer = {
   id: 'merged-line',
   type: 'line' as const,
+  filter: ['in', ['get', '_geomType'], ['literal', ['LineString', 'MultiLineString']]] as any,
   paint: {
     'line-color': '#ef4444',
     'line-width': 4,
   },
 };
+
 const fillLayer = {
   id: 'merged-fill',
   type: 'fill' as const,
+  filter: ['in', ['get', '_geomType'], ['literal', ['Polygon', 'MultiPolygon']]] as any,
   paint: {
     'fill-color': '#3b82f6',
     'fill-opacity': 0.4,
   },
 };
 
+const pointLayer = {
+  id: 'merged-point',
+  type: 'circle' as const,
+  filter: ['in', ['get', '_geomType'], ['literal', ['Point', 'MultiPoint']]] as any,
+  paint: {
+    'circle-radius': 6,
+    'circle-color': '#f59e0b',
+    'circle-stroke-width': 2,
+    'circle-stroke-color': '#fff',
+  },
+};
+
+const pointLabelLayer = {
+  id: 'merged-point-label',
+  type: 'symbol' as const,
+  filter: ['in', ['get', '_geomType'], ['literal', ['Point', 'MultiPoint']]] as any,
+  layout: {
+    'text-field': ['get', 'name'] as any,
+    'text-size': 12,
+    'text-offset': [0, 1.5] as [number, number],
+    'text-anchor': 'top' as const,
+  },
+  paint: {
+    'text-color': '#374151',
+    'text-halo-color': '#fff',
+    'text-halo-width': 1,
+  },
+};
+
 // マーカー用レイヤー
-const markerLayer = {
+const hoverMarkerLayer = {
   id: 'hover-marker',
   type: 'circle' as const,
   paint: {
@@ -40,20 +72,37 @@ const markerLayer = {
   },
 };
 
-// hoveredIndex: グラフ上でホバーした点番号
+function extractLineCoords(features: GeoJSONFeature[]): number[][] {
+  const coords: number[][] = [];
+  for (const f of features) {
+    if (f.geometry.type === 'LineString') {
+      coords.push(...f.geometry.coordinates);
+    } else if (f.geometry.type === 'MultiLineString') {
+      coords.push(...f.geometry.coordinates.flat());
+    }
+  }
+  return coords;
+}
+
 interface MapViewProps {
   hoveredIndex?: number | null;
 }
 
 export default function MapView({ hoveredIndex }: MapViewProps) {
   const mergedGeojson = useGeojsonStore((s) => s.mergedGeojson);
-  const geojsonData = useMemo(() =>
-    mergedGeojson ? {
-      type: 'FeatureCollection',
-      features: [mergedGeojson],
-    } : null,
-    [mergedGeojson]
-  );
+
+  // _geomType プロパティを付与してフィルタリング可能にする
+  const geojsonData = useMemo(() => {
+    if (!mergedGeojson) return null;
+    return {
+      type: 'FeatureCollection' as const,
+      features: mergedGeojson.features.map((f) => ({
+        ...f,
+        properties: { ...f.properties, _geomType: f.geometry.type },
+      })),
+    };
+  }, [mergedGeojson]);
+
   const mapRef = useRef<MapRef>(null);
 
   // GeoJSON領域でバウンド
@@ -67,27 +116,18 @@ export default function MapView({ hoveredIndex }: MapViewProps) {
     ], { padding: 40, duration: 500 } as any);
   }, [mergedGeojson]);
 
-  // マーカー用GeoJSON生成
+  // マーカー用GeoJSON生成（LineString系の座標からhoveredIndexで取得）
   const markerGeojson = useMemo(() => {
     if (!mergedGeojson || hoveredIndex == null) return null;
-    let coord: number[] | undefined;
-    if (mergedGeojson.geometry.type === 'LineString') {
-      coord = mergedGeojson.geometry.coordinates[hoveredIndex];
-    } else if (mergedGeojson.geometry.type === 'MultiLineString') {
-      const flat = mergedGeojson.geometry.coordinates.flat();
-      coord = flat[hoveredIndex];
-    } else if (mergedGeojson.geometry.type === 'Polygon') {
-      coord = mergedGeojson.geometry.coordinates.flat()[hoveredIndex];
-    } else if (mergedGeojson.geometry.type === 'MultiPolygon') {
-      coord = mergedGeojson.geometry.coordinates.flat(2)[hoveredIndex];
-    }
+    const lineCoords = extractLineCoords(mergedGeojson.features);
+    const coord = lineCoords[hoveredIndex];
     if (!coord) return null;
     return {
-      type: 'FeatureCollection',
+      type: 'FeatureCollection' as const,
       features: [
         {
-          type: 'Feature',
-          geometry: { type: 'Point', coordinates: coord },
+          type: 'Feature' as const,
+          geometry: { type: 'Point' as const, coordinates: coord },
           properties: {},
         },
       ],
@@ -107,16 +147,15 @@ export default function MapView({ hoveredIndex }: MapViewProps) {
       >
         {geojsonData && (
           <Source id="merged" type="geojson" data={geojsonData}>
-            {mergedGeojson && (mergedGeojson.geometry.type === 'Polygon' || mergedGeojson.geometry.type === 'MultiPolygon') ? (
-              <Layer {...fillLayer} />
-            ) : (
-              <Layer {...lineLayer} />
-            )}
+            <Layer {...lineLayer} />
+            <Layer {...fillLayer} />
+            <Layer {...pointLayer} />
+            <Layer {...pointLabelLayer} />
           </Source>
         )}
         {markerGeojson && (
           <Source id="hover-marker" type="geojson" data={markerGeojson}>
-            <Layer {...markerLayer} />
+            <Layer {...hoverMarkerLayer} />
           </Source>
         )}
       </Map>

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -1,7 +1,8 @@
 import { useMemo, useRef, useEffect } from 'react';
 import Map, { Source, Layer, ViewState, MapRef } from '@vis.gl/react-maplibre';
-import { useGeojsonStore, GeoJSONFeature } from '@/store/geojsonStore';
+import { useGeojsonStore } from '@/store/geojsonStore';
 import { getGeojsonBounds } from '@/utils/geojsonBounds';
+import { extractLineCoords } from '@/utils/extractLineCoords';
 
 // MapTiler Streets スタイル
 const MAP_STYLE = `https://api.maptiler.com/maps/streets/style.json?key=${import.meta.env.VITE_MAPTILER_KEY}`;
@@ -14,7 +15,7 @@ const INITIAL_VIEW_STATE: Partial<ViewState> = {
 const lineLayer = {
   id: 'merged-line',
   type: 'line' as const,
-  filter: ['in', ['get', '_geomType'], ['literal', ['LineString', 'MultiLineString']]] as any,
+  filter: ['in', ['geometry-type'], ['literal', ['LineString', 'MultiLineString']]] as any,
   paint: {
     'line-color': '#ef4444',
     'line-width': 4,
@@ -24,7 +25,7 @@ const lineLayer = {
 const fillLayer = {
   id: 'merged-fill',
   type: 'fill' as const,
-  filter: ['in', ['get', '_geomType'], ['literal', ['Polygon', 'MultiPolygon']]] as any,
+  filter: ['in', ['geometry-type'], ['literal', ['Polygon', 'MultiPolygon']]] as any,
   paint: {
     'fill-color': '#3b82f6',
     'fill-opacity': 0.4,
@@ -34,7 +35,7 @@ const fillLayer = {
 const pointLayer = {
   id: 'merged-point',
   type: 'circle' as const,
-  filter: ['in', ['get', '_geomType'], ['literal', ['Point', 'MultiPoint']]] as any,
+  filter: ['in', ['geometry-type'], ['literal', ['Point', 'MultiPoint']]] as any,
   paint: {
     'circle-radius': 6,
     'circle-color': '#f59e0b',
@@ -46,7 +47,7 @@ const pointLayer = {
 const pointLabelLayer = {
   id: 'merged-point-label',
   type: 'symbol' as const,
-  filter: ['in', ['get', '_geomType'], ['literal', ['Point', 'MultiPoint']]] as any,
+  filter: ['in', ['geometry-type'], ['literal', ['Point', 'MultiPoint']]] as any,
   layout: {
     'text-field': ['get', 'name'] as any,
     'text-size': 12,
@@ -72,37 +73,12 @@ const hoverMarkerLayer = {
   },
 };
 
-function extractLineCoords(features: GeoJSONFeature[]): number[][] {
-  const coords: number[][] = [];
-  for (const f of features) {
-    if (f.geometry.type === 'LineString') {
-      coords.push(...f.geometry.coordinates);
-    } else if (f.geometry.type === 'MultiLineString') {
-      coords.push(...f.geometry.coordinates.flat());
-    }
-  }
-  return coords;
-}
-
 interface MapViewProps {
   hoveredIndex?: number | null;
 }
 
 export default function MapView({ hoveredIndex }: MapViewProps) {
   const mergedGeojson = useGeojsonStore((s) => s.mergedGeojson);
-
-  // _geomType プロパティを付与してフィルタリング可能にする
-  const geojsonData = useMemo(() => {
-    if (!mergedGeojson) return null;
-    return {
-      type: 'FeatureCollection' as const,
-      features: mergedGeojson.features.map((f) => ({
-        ...f,
-        properties: { ...f.properties, _geomType: f.geometry.type },
-      })),
-    };
-  }, [mergedGeojson]);
-
   const mapRef = useRef<MapRef>(null);
 
   // GeoJSON領域でバウンド
@@ -145,8 +121,8 @@ export default function MapView({ hoveredIndex }: MapViewProps) {
         initialViewState={INITIAL_VIEW_STATE}
         style={{ width: '100%', height: '100%' }}
       >
-        {geojsonData && (
-          <Source id="merged" type="geojson" data={geojsonData}>
+        {mergedGeojson && (
+          <Source id="merged" type="geojson" data={mergedGeojson as any}>
             <Layer {...lineLayer} />
             <Layer {...fillLayer} />
             <Layer {...pointLayer} />

--- a/src/components/ResizableMapAndChart.tsx
+++ b/src/components/ResizableMapAndChart.tsx
@@ -45,7 +45,7 @@ export default function ResizableMapAndChart({
       </div>
       {/* 高度グラフ領域 */}
       <div style={{ flexBasis: `${(1 - mapHeightRatio) * 100}%`, minHeight: 0, width: '100%' }}>
-        <AltitudeChartPanel feature={mergedGeojson} onHoverIndex={setHoveredIndex} />
+        <AltitudeChartPanel fc={mergedGeojson} onHoverIndex={setHoveredIndex} />
       </div>
       {/* ドラッグ操作イベントをbodyにバインド */}
       {dragging && (

--- a/src/store/geojsonStore.ts
+++ b/src/store/geojsonStore.ts
@@ -17,9 +17,13 @@ export type GeoJSON = {
 interface GeojsonState {
   mergedGeojson: GeoJSON | null;
   setMergedGeojson: (fc: GeoJSON | null) => void;
+  rawGpxTexts: string[];
+  setRawGpxTexts: (texts: string[]) => void;
 }
 
 export const useGeojsonStore = create<GeojsonState>((set) => ({
   mergedGeojson: null,
   setMergedGeojson: (fc) => set({ mergedGeojson: fc }),
+  rawGpxTexts: [],
+  setRawGpxTexts: (texts) => set({ rawGpxTexts: texts }),
 }));

--- a/src/store/geojsonStore.ts
+++ b/src/store/geojsonStore.ts
@@ -15,11 +15,11 @@ export type GeoJSON = {
 };
 
 interface GeojsonState {
-  mergedGeojson: GeoJSONFeature | null;
-  setMergedGeojson: (feature: GeoJSONFeature | null) => void;
+  mergedGeojson: GeoJSON | null;
+  setMergedGeojson: (fc: GeoJSON | null) => void;
 }
 
 export const useGeojsonStore = create<GeojsonState>((set) => ({
   mergedGeojson: null,
-  setMergedGeojson: (feature) => set({ mergedGeojson: feature }),
+  setMergedGeojson: (fc) => set({ mergedGeojson: fc }),
 }));

--- a/src/utils/download.ts
+++ b/src/utils/download.ts
@@ -1,17 +1,26 @@
 import { GeoJSON } from '@/store/geojsonStore';
+import { mergeGpxTexts } from '@/utils/gpxMerge';
 import { geojsonToGpx } from '@/utils/geojsonToGpx';
 
-export function downloadGeoData(fc: GeoJSON, ext: 'geojson' | 'gpx') {
+export function downloadGeoData(fc: GeoJSON, ext: 'geojson' | 'gpx', rawGpxTexts: string[]) {
   let blob: Blob, filename: string;
   if (ext === 'geojson') {
     blob = new Blob([JSON.stringify(fc, null, 2)], { type: 'application/geo+json' });
     filename = 'merged.geojson';
   } else {
-    const { gpx, skippedTypes } = geojsonToGpx(fc);
-    if (skippedTypes.length > 0) {
-      alert(`GPXエクスポートで未対応のgeometry typeがスキップされました: ${skippedTypes.join(', ')}`);
+    let gpxText: string;
+    if (rawGpxTexts.length > 0) {
+      // 元のGPX XMLをそのままマージ（情報欠落なし）
+      gpxText = mergeGpxTexts(rawGpxTexts);
+    } else {
+      // GeoJSONのみの場合はGeoJSON→GPX変換
+      const { gpx, skippedTypes } = geojsonToGpx(fc);
+      if (skippedTypes.length > 0) {
+        alert(`GPXエクスポートで未対応のgeometry typeがスキップされました: ${skippedTypes.join(', ')}`);
+      }
+      gpxText = gpx;
     }
-    blob = new Blob([gpx], { type: 'application/gpx+xml' });
+    blob = new Blob([gpxText], { type: 'application/gpx+xml' });
     filename = 'merged.gpx';
   }
   const url = URL.createObjectURL(blob);

--- a/src/utils/download.ts
+++ b/src/utils/download.ts
@@ -1,18 +1,13 @@
-import { GeoJSONFeature } from '@/store/geojsonStore';
+import { GeoJSON } from '@/store/geojsonStore';
 import { geojsonToGpx } from '@/utils/geojsonToGpx';
 
-export function downloadGeoData(feature: GeoJSONFeature, ext: 'geojson' | 'gpx') {
+export function downloadGeoData(fc: GeoJSON, ext: 'geojson' | 'gpx') {
   let blob: Blob, filename: string;
   if (ext === 'geojson') {
-    blob = new Blob([
-      JSON.stringify({
-        type: 'FeatureCollection',
-        features: [feature],
-      }, null, 2)
-    ], { type: 'application/geo+json' });
+    blob = new Blob([JSON.stringify(fc, null, 2)], { type: 'application/geo+json' });
     filename = 'merged.geojson';
   } else {
-    const gpx = geojsonToGpx(feature);
+    const gpx = geojsonToGpx(fc);
     blob = new Blob([gpx], { type: 'application/gpx+xml' });
     filename = 'merged.gpx';
   }

--- a/src/utils/download.ts
+++ b/src/utils/download.ts
@@ -7,7 +7,10 @@ export function downloadGeoData(fc: GeoJSON, ext: 'geojson' | 'gpx') {
     blob = new Blob([JSON.stringify(fc, null, 2)], { type: 'application/geo+json' });
     filename = 'merged.geojson';
   } else {
-    const gpx = geojsonToGpx(fc);
+    const { gpx, skippedTypes } = geojsonToGpx(fc);
+    if (skippedTypes.length > 0) {
+      alert(`GPXエクスポートで未対応のgeometry typeがスキップされました: ${skippedTypes.join(', ')}`);
+    }
     blob = new Blob([gpx], { type: 'application/gpx+xml' });
     filename = 'merged.gpx';
   }

--- a/src/utils/extractLineCoords.ts
+++ b/src/utils/extractLineCoords.ts
@@ -1,0 +1,16 @@
+import { GeoJSONFeature } from '@/store/geojsonStore';
+
+/**
+ * FeatureCollectionのfeaturesからLineString/MultiLineStringの座標を抽出して結合する
+ */
+export function extractLineCoords(features: GeoJSONFeature[]): number[][] {
+  const coords: number[][] = [];
+  for (const f of features) {
+    if (f.geometry.type === 'LineString') {
+      coords.push(...f.geometry.coordinates);
+    } else if (f.geometry.type === 'MultiLineString') {
+      coords.push(...f.geometry.coordinates.flat());
+    }
+  }
+  return coords;
+}

--- a/src/utils/fileToGeojson.ts
+++ b/src/utils/fileToGeojson.ts
@@ -1,8 +1,8 @@
 import { gpxToGeojson } from '@/utils/gpxToGeojson';
 import { FeatureCollection } from 'geojson';
 
-export async function fileToGeojson(file: File): Promise<FeatureCollection | null> {
-  const text = await file.text();
+export async function fileToGeojson(file: File, rawText?: string): Promise<FeatureCollection | null> {
+  const text = rawText ?? await file.text();
   let json = null;
   if (file.name.toLowerCase().endsWith('.gpx') || file.type === 'application/gpx+xml') {
     json = await gpxToGeojson(text);

--- a/src/utils/geojsonBounds.ts
+++ b/src/utils/geojsonBounds.ts
@@ -1,17 +1,18 @@
-import { GeoJSONFeature } from '@/store/geojsonStore';
+import { GeoJSON, GeoJSONFeature } from '@/store/geojsonStore';
 
-// GeoJSON Featureのboundsを[minLng, minLat, maxLng, maxLat]で返す
-export function getGeojsonBounds(feature: GeoJSONFeature): [number, number, number, number] {
-  let coords: number[][] = [];
-  if (feature.geometry.type === 'LineString') {
-    coords = feature.geometry.coordinates;
-  } else if (feature.geometry.type === 'Polygon') {
-    coords = feature.geometry.coordinates.flat();
-  } else if (feature.geometry.type === 'MultiLineString' || feature.geometry.type === 'MultiPolygon') {
-    coords = feature.geometry.coordinates.flat(2);
-  } else {
-    return [139.767, 35.681, 139.767, 35.681]; // fallback
-  }
+function extractCoords(feature: GeoJSONFeature): number[][] {
+  const { type, coordinates } = feature.geometry;
+  if (type === 'Point') return [coordinates];
+  if (type === 'MultiPoint' || type === 'LineString') return coordinates;
+  if (type === 'Polygon' || type === 'MultiLineString') return coordinates.flat();
+  if (type === 'MultiPolygon') return coordinates.flat(2);
+  return [];
+}
+
+// GeoJSON FeatureCollectionのboundsを[minLng, minLat, maxLng, maxLat]で返す
+export function getGeojsonBounds(fc: GeoJSON): [number, number, number, number] | null {
+  const coords = fc.features.flatMap(extractCoords);
+  if (coords.length === 0) return null;
   const lons = coords.map((c) => c[0]);
   const lats = coords.map((c) => c[1]);
   return [

--- a/src/utils/geojsonMerge.ts
+++ b/src/utils/geojsonMerge.ts
@@ -1,37 +1,15 @@
-import { GeoJSON, GeoJSONFeature } from '@/store/geojsonStore';
+import { GeoJSON } from '@/store/geojsonStore';
 
 /**
- * 複数のGeoJSON FeatureCollectionを1つのFeatureに結合
- * @param geojsons FeatureCollectionの配列
- * @returns 1つのFeature、またはnull
+ * 複数のGeoJSON FeatureCollectionを1つのFeatureCollectionに結合
+ * geometry typeが混在していてもそのまま保持する
  */
-export function mergeGeojsons(geojsons: GeoJSON[]): GeoJSONFeature | null {
+export function mergeGeojsons(geojsons: GeoJSON[]): GeoJSON | null {
   if (geojsons.length === 0) return null;
-  const geometryType = geojsons[0].features[0]?.geometry.type;
-  if (!geometryType) return null;
-  let mergedCoordinates: any[] = [];
-  for (const geojson of geojsons) {
-    for (const feature of geojson.features) {
-      if (feature.geometry.type !== geometryType) return null;
-      if (geometryType === 'LineString') {
-        mergedCoordinates = mergedCoordinates.concat(feature.geometry.coordinates);
-      } else if (geometryType === 'Polygon') {
-        mergedCoordinates = mergedCoordinates.concat(feature.geometry.coordinates);
-      } else if (geometryType === 'MultiLineString') {
-        mergedCoordinates = mergedCoordinates.concat(feature.geometry.coordinates);
-      } else if (geometryType === 'MultiPolygon') {
-        mergedCoordinates = mergedCoordinates.concat(feature.geometry.coordinates);
-      } else {
-        return null;
-      }
-    }
-  }
+  const features = geojsons.flatMap((g) => g.features);
+  if (features.length === 0) return null;
   return {
-    type: 'Feature',
-    geometry: {
-      type: geometryType,
-      coordinates: mergedCoordinates,
-    },
-    properties: {},
+    type: 'FeatureCollection',
+    features,
   };
 }

--- a/src/utils/geojsonToGpx.ts
+++ b/src/utils/geojsonToGpx.ts
@@ -28,6 +28,10 @@ function featureToWpts(feature: GeoJSONFeature): string[] {
   if (typeof ele === 'number') wpt += `\n  <ele>${ele}</ele>`;
   if (typeof name === 'string' && name) wpt += `\n  <name>${escapeXml(name)}</name>`;
   if (typeof type === 'string' && type) wpt += `\n  <type>${escapeXml(type)}</type>`;
+  const extensionsXml = feature.properties?._extensionsXml;
+  if (typeof extensionsXml === 'string' && extensionsXml) {
+    wpt += `\n  <extensions>\n    ${extensionsXml}\n  </extensions>`;
+  }
   wpt += `\n</wpt>`;
   return [wpt];
 }
@@ -69,7 +73,9 @@ export function geojsonToGpx(fc: GeoJSON): GpxExportResult {
   if (wpts.length > 0) body += '\n';
 
   const gpx = `<?xml version="1.0" encoding="UTF-8"?>\n` +
-    `<gpx version="1.1" creator="gpx-merge" xmlns="http://www.topografix.com/GPX/1/1">\n` +
+    `<gpx version="1.1" creator="gpx-merge"\n` +
+    `     xmlns="http://www.topografix.com/GPX/1/1"\n` +
+    `     xmlns:gpxx="http://www.garmin.com/xmlschemas/GpxExtensions/v3">\n` +
     body +
     `</gpx>\n`;
   return { gpx, skippedTypes: [...skippedTypes] };

--- a/src/utils/geojsonToGpx.ts
+++ b/src/utils/geojsonToGpx.ts
@@ -26,8 +26,8 @@ function featureToWpts(feature: GeoJSONFeature): string[] {
   const type = feature.properties?.type;
   let wpt = `<wpt lat="${lat}" lon="${lon}">`;
   if (typeof ele === 'number') wpt += `\n  <ele>${ele}</ele>`;
-  if (name) wpt += `\n  <name>${escapeXml(name)}</name>`;
-  if (type) wpt += `\n  <type>${escapeXml(type)}</type>`;
+  if (typeof name === 'string' && name) wpt += `\n  <name>${escapeXml(name)}</name>`;
+  if (typeof type === 'string' && type) wpt += `\n  <type>${escapeXml(type)}</type>`;
   wpt += `\n</wpt>`;
   return [wpt];
 }
@@ -41,11 +41,22 @@ function escapeXml(str: string): string {
     .replace(/'/g, '&apos;');
 }
 
-export function geojsonToGpx(fc: GeoJSON): string {
+const SUPPORTED_GPX_TYPES = new Set(['LineString', 'MultiLineString', 'Point']);
+
+export type GpxExportResult = {
+  gpx: string;
+  skippedTypes: string[];
+};
+
+export function geojsonToGpx(fc: GeoJSON): GpxExportResult {
   const trksegs: string[] = [];
   const wpts: string[] = [];
+  const skippedTypes = new Set<string>();
 
   for (const feature of fc.features) {
+    if (!SUPPORTED_GPX_TYPES.has(feature.geometry.type)) {
+      skippedTypes.add(feature.geometry.type);
+    }
     trksegs.push(...featureToTrksegs(feature));
     wpts.push(...featureToWpts(feature));
   }
@@ -57,8 +68,9 @@ export function geojsonToGpx(fc: GeoJSON): string {
   body += wpts.join('\n');
   if (wpts.length > 0) body += '\n';
 
-  return `<?xml version="1.0" encoding="UTF-8"?>\n` +
+  const gpx = `<?xml version="1.0" encoding="UTF-8"?>\n` +
     `<gpx version="1.1" creator="gpx-merge" xmlns="http://www.topografix.com/GPX/1/1">\n` +
     body +
     `</gpx>\n`;
+  return { gpx, skippedTypes: [...skippedTypes] };
 }

--- a/src/utils/geojsonToGpx.ts
+++ b/src/utils/geojsonToGpx.ts
@@ -1,26 +1,64 @@
-// GeoJSON(LineString/MultiLineString) → GPX文字列変換ユーティリティ
-import { GeoJSONFeature } from '@/store/geojsonStore';
+import { GeoJSON, GeoJSONFeature } from '@/store/geojsonStore';
 
-export function geojsonToGpx(feature: GeoJSONFeature): string {
+function featureToTrksegs(feature: GeoJSONFeature): string[] {
   let segments: number[][][] = [];
   if (feature.geometry.type === 'LineString') {
     segments = [feature.geometry.coordinates];
   } else if (feature.geometry.type === 'MultiLineString') {
     segments = feature.geometry.coordinates;
   } else {
-    throw new Error('Only LineString or MultiLineString supported for GPX export');
+    return [];
   }
-
-  const trksegs = segments.map(seg =>
+  return segments.map(seg =>
     `<trkseg>\n` +
     seg.map(coord => {
       const [lon, lat, ele] = coord;
-      return `<trkpt lat=\"${lat}\" lon=\"${lon}\">${typeof ele === 'number' ? `\n  <ele>${ele}</ele>` : ''}\n</trkpt>`;
+      return `<trkpt lat="${lat}" lon="${lon}">${typeof ele === 'number' ? `\n  <ele>${ele}</ele>` : ''}\n</trkpt>`;
     }).join('\n') +
     `\n</trkseg>`
-  ).join('\n');
+  );
+}
 
-  return `<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n` +
-    `<gpx version=\"1.1\" creator=\"gpx-merge\" xmlns=\"http://www.topografix.com/GPX/1/1\">\n` +
-    `<trk>\n${trksegs}\n</trk>\n</gpx>\n`;
+function featureToWpts(feature: GeoJSONFeature): string[] {
+  if (feature.geometry.type !== 'Point') return [];
+  const [lon, lat, ele] = feature.geometry.coordinates;
+  const name = feature.properties?.name;
+  const type = feature.properties?.type;
+  let wpt = `<wpt lat="${lat}" lon="${lon}">`;
+  if (typeof ele === 'number') wpt += `\n  <ele>${ele}</ele>`;
+  if (name) wpt += `\n  <name>${escapeXml(name)}</name>`;
+  if (type) wpt += `\n  <type>${escapeXml(type)}</type>`;
+  wpt += `\n</wpt>`;
+  return [wpt];
+}
+
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+export function geojsonToGpx(fc: GeoJSON): string {
+  const trksegs: string[] = [];
+  const wpts: string[] = [];
+
+  for (const feature of fc.features) {
+    trksegs.push(...featureToTrksegs(feature));
+    wpts.push(...featureToWpts(feature));
+  }
+
+  let body = '';
+  if (trksegs.length > 0) {
+    body += `<trk>\n${trksegs.join('\n')}\n</trk>\n`;
+  }
+  body += wpts.join('\n');
+  if (wpts.length > 0) body += '\n';
+
+  return `<?xml version="1.0" encoding="UTF-8"?>\n` +
+    `<gpx version="1.1" creator="gpx-merge" xmlns="http://www.topografix.com/GPX/1/1">\n` +
+    body +
+    `</gpx>\n`;
 }

--- a/src/utils/gpxMerge.ts
+++ b/src/utils/gpxMerge.ts
@@ -1,0 +1,101 @@
+/**
+ * 複数のGPX XMLテキストをXMLレベルでマージする
+ * 元のデータ（extensions, namespace等）を完全に保持する
+ */
+export function mergeGpxTexts(gpxTexts: string[]): string {
+  if (gpxTexts.length === 0) return '';
+  if (gpxTexts.length === 1) return gpxTexts[0];
+
+  const parser = new DOMParser();
+
+  // 全GPXからnamespace宣言、trk, rte, wpt要素を収集
+  const namespaces = new Map<string, string>();
+  const trkElements: string[] = [];
+  const rteElements: string[] = [];
+  const wptElements: string[] = [];
+  const metadataElements: string[] = [];
+
+  // 最初のGPXのcreator属性を使用
+  let creator = 'gpx-merge';
+
+  for (let i = 0; i < gpxTexts.length; i++) {
+    const doc = parser.parseFromString(gpxTexts[i], 'application/xml');
+    const gpxEl = doc.documentElement;
+
+    if (i === 0 && gpxEl.getAttribute('creator')) {
+      creator = gpxEl.getAttribute('creator')!;
+    }
+
+    // namespace宣言を収集
+    for (let j = 0; j < gpxEl.attributes.length; j++) {
+      const attr = gpxEl.attributes[j];
+      if (attr.name.startsWith('xmlns:')) {
+        namespaces.set(attr.name, attr.value);
+      }
+    }
+
+    // metadata (最初のファイルのみ)
+    if (i === 0) {
+      for (const child of Array.from(gpxEl.childNodes)) {
+        if (child.nodeType === 1 && (child as Element).tagName === 'metadata') {
+          metadataElements.push(nodeToString(child as Element, gpxEl));
+        }
+      }
+    }
+
+    // trk, rte, wpt要素を収集（直接の子要素のみ）
+    for (const child of Array.from(gpxEl.childNodes)) {
+      if (child.nodeType !== 1) continue;
+      const el = child as Element;
+      const tag = el.tagName;
+      const str = nodeToString(el, gpxEl);
+      if (tag === 'trk') trkElements.push(str);
+      else if (tag === 'rte') rteElements.push(str);
+      else if (tag === 'wpt') wptElements.push(str);
+    }
+  }
+
+  // namespace宣言を構築
+  const nsDecls = Array.from(namespaces.entries())
+    .map(([name, value]) => `${name}="${value}"`)
+    .join('\n     ');
+
+  // GPXドキュメントを構築
+  let gpx = `<?xml version="1.0" encoding="UTF-8"?>\n`;
+  gpx += `<gpx version="1.1" creator="${creator}"\n`;
+  gpx += `     xmlns="http://www.topografix.com/GPX/1/1"`;
+  if (nsDecls) gpx += `\n     ${nsDecls}`;
+  gpx += `>\n`;
+
+  for (const m of metadataElements) gpx += `  ${m}\n`;
+  for (const w of wptElements) gpx += `  ${w}\n`;
+  for (const r of rteElements) gpx += `  ${r}\n`;
+  for (const t of trkElements) gpx += `  ${t}\n`;
+
+  gpx += `</gpx>\n`;
+  return gpx;
+}
+
+/**
+ * 要素をシリアライズし、ルート要素で既に宣言済みのnamespace宣言を子要素から除去する
+ */
+function nodeToString(el: Element, gpxRoot: Element): string {
+  const serializer = new XMLSerializer();
+  let str = serializer.serializeToString(el);
+
+  // ルート要素のデフォルトnamespace宣言を子要素から除去
+  const defaultNs = gpxRoot.getAttribute('xmlns');
+  if (defaultNs) {
+    str = str.replaceAll(` xmlns="${defaultNs}"`, '');
+  }
+
+  // ルート要素のプレフィックス付きnamespace宣言を子要素から除去
+  for (let i = 0; i < gpxRoot.attributes.length; i++) {
+    const attr = gpxRoot.attributes[i];
+    if (attr.name.startsWith('xmlns:')) {
+      str = str.replaceAll(` ${attr.name}="${attr.value}"`, '');
+    }
+  }
+
+  return str;
+}

--- a/src/utils/gpxToGeojson.ts
+++ b/src/utils/gpxToGeojson.ts
@@ -1,10 +1,8 @@
-// GPX(XML文字列)→GeoJSON FeatureCollection 変換
-// @tmcw/togeojsonを使う想定
+// GPX(XML文字列)→GeoJSON FeatureCollection 変換（表示用）
 import { FeatureCollection } from 'geojson';
 import { gpx } from '@tmcw/togeojson';
 
 export async function gpxToGeojson(gpxText: string): Promise<FeatureCollection | null> {
-  // @tmcw/togeojsonはXMLDocumentを受け取るので、パースが必要
   try {
     const parser = new DOMParser();
     const xml = parser.parseFromString(gpxText, 'application/xml');


### PR DESCRIPTION
## Summary
- storeの`mergedGeojson`を単一Feature→FeatureCollectionに変更
- trk(LineString)とwpt(Point)が混在するGPXファイルでも情報を損なわずマージ・表示・エクスポート可能に
- 地図上でwptをポイント+名前ラベルで表示

Closes #3

## Test plan
- [x] trk+wptが混在するGPXファイルを読み込み、地図上にルートとウェイポイントが表示されることを確認
- [x] 標高グラフがLineString系データから正しく生成されることを確認
- [ ] GPXダウンロードでtrk+wptの両方が出力されることを確認
- [ ] GeoJSONダウンロードで全Featureが保持されていることを確認
- [ ] 従来のLineStringのみのファイルが引き続き正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)